### PR TITLE
Remove an extra comma

### DIFF
--- a/daemon-scheduler/generated/v1/swagger.json
+++ b/daemon-scheduler/generated/v1/swagger.json
@@ -52,7 +52,7 @@
             "in": "query",
             "name": "cluster",
             "type": "string",
-            "description": "Cluster ARN",
+            "description": "Cluster ARN"
         }
     },
     "paths": {


### PR DESCRIPTION
#### Summary
Remove an extra comma in swagger.json file that causes format error in the RHEL environment.

#### Implementation details
Remove an comma in Daemon Scheduler's swagger.json.

#### Testing
<!-- How was this tested? -->
- [x ] cluster-state-service binary built locally and unit-tests pass (`cd cluster-state-service; make; cd ../`)
- [ x] cluster-state-service build in Docker succeeds (`cd cluster-state-service; make release; cd ../`)
- [ x] daemon-scheduler binary built locally and unit-tests pass (`cd daemon-scheduler; make; cd ../`)
- [ x] daemon-scheduler build in Docker succeeds (`cd daemon-scheduler; make release; cd ../`)

New tests cover the changes: yes

#### Description for the changelog
Remove an extra comma in swagger.json file that causes format error in the RHEL environment.

#### Licensing

This contribution is under the terms of the Apache 2.0 License: Yes

Remove an extra comma in swagger.json file that causes format error in the RHEL environment.